### PR TITLE
Spec updates

### DIFF
--- a/platform-sharing/v1.0.yaml
+++ b/platform-sharing/v1.0.yaml
@@ -145,10 +145,11 @@ components:
           example: 'B'
         booking_information:
           type: array
-          description: This array must be populated for the following time periods only if a registration_number is provided
+          description: |
+            This array must be populated for the following time periods only if a registration_number is provided
             - January 1 of the current year through the current day
             - The current day through January 1 of next calendar year
-            - January 1 of the next calendar year through January 1 of the following year
+            - January 1 of the next calendar year through January 1 of the following year _This date range is only required for Appendix A_
           items:
             $ref: '#/components/schemas/BookingInformation'
         unique_host_id:
@@ -240,13 +241,14 @@ components:
           example: 33
         ltr_nights_booked:
           type: integer
-          description: The number of nights the rental unit has already been rented within date range for non-Short-Term Rental stays through the Hosting Platform in the calendar year.
+          description: |
+            The number of nights the rental unit has already been rented within date range for non-Short-Term Rental stays through the Hosting Platform in the calendar year.
+            > This field is only required for Appendix A.
           example: 0
       required:
         - start_date
         - end_date
         - str_nights_booked
-        - ltr_nights_booked
     GenericErrorMessage:
       type: object
       properties:

--- a/platform-sharing/v1.0.yaml
+++ b/platform-sharing/v1.0.yaml
@@ -50,7 +50,7 @@ paths:
               examples:
                 example-1:
                   value:
-                    message: Can not process more than 100 records in one request. Please reduce the number of listings to 100 or less.
+                    message: Cannot process more than 100 records in one request. Please reduce the number of listings to 100 or less.
         '422':
           description: Unprocessable Entity
           content:
@@ -65,6 +65,16 @@ paths:
                       '0':
                         host_email_address:
                           - Not a valid email address
+        '429':
+          description: Too many requests sent, please limit requests to one per second.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericErrorMessage'
+              examples:
+                example-1:
+                  value:
+                    message: Cannot process more than one request per second. Please try again later.
       description: Share STR information with Host Compliance
     parameters:
       - schema:


### PR DESCRIPTION
Make minor adjustments to the existing spec. Highlights include

- Adds 429 "rate limiting”, limiting requests to 1 per second.
- Makes next calendar year information optional. Only required if following Appendix A.
- Makes LTR nights booked optional. Only required if following Appendix A.