### PR TITLE
Only require situs address for exemption codes 02, 03, and 04

### DIFF
--- a/platform-sharing/v1.0.yaml
+++ b/platform-sharing/v1.0.yaml
@@ -88,7 +88,7 @@ components:
   schemas:
     SitusAddress:
       type: object
-      description: The complete physical address of the rental unit as provided to the Hosting Platform by the Host. Required if registration_number is not provided.
+      description: The complete physical address of the rental unit as provided to the Hosting Platform by the Host. Required for exemption code "02", "03", and "04" only.
       properties:
         street_address:
           type: string


### PR DESCRIPTION
To align with specs, require situs address for certain exemption codes (not `"01"`)